### PR TITLE
Reinitialize controller when setting animation

### DIFF
--- a/source/FlareComponent.js
+++ b/source/FlareComponent.js
@@ -402,6 +402,11 @@ export default class FlareComponent extends React.Component
 				);
 				actorArtboard.initialize(graphics);
 
+				if(controller) 
+				{
+					controller.initialize(this._ActorArtboard);
+				}
+
 				this._RuntimeAnimationIndex = desiredAnimationIndex;
 				this._RuntimeAnimation =
 					desiredAnimationIndex !== -1 ?


### PR DESCRIPTION
This is to prevent that when creating a component:

`<FlareComponent width={200} height={200} file="flare_file.flr" controller={customController} animationName="idle" />`

The controller has the correct references to the artboard that has ben re-instanced.