### PR TITLE
Rename componentWillReceiveProps to UNSAFE_componentWillReceiveProps

### DIFF
--- a/source/FlareComponent.js
+++ b/source/FlareComponent.js
@@ -49,7 +49,7 @@ export default class FlareComponent extends React.Component
 		return this.canvasRef.current;
 	}
 
-	componentWillReceiveProps(nextProps)
+	UNSAFE_componentWillReceiveProps(nextProps)
 	{
 		if (nextProps.isPaused !== this.props.isPaused)
 		{


### PR DESCRIPTION
Getting warning in non-strict mode. In React 17.x, only the UNSAFE_ name will work.